### PR TITLE
added 'database' filter tag

### DIFF
--- a/feeds.json
+++ b/feeds.json
@@ -50,7 +50,12 @@
   {
     "title": "Tinybird Engineering Blog",
     "url": "https://www.tinybird.co/blog-posts/rss.xml",
-    "filter_tags": ["clickhouse", "postgres", "real-time analytics"]
+    "filter_tags": [
+      "clickhouse",
+      "postgres",
+      "real-time analytics",
+      "database"
+    ]
   },
   {
     "title": "Hack MySQL",


### PR DESCRIPTION
Since we don't include tags in our RSS feed, adding a tag based on title that should include additional relevant posts.
