### PR TITLE
Add ParadeDB Blog

### DIFF
--- a/feeds.json
+++ b/feeds.json
@@ -79,5 +79,9 @@
   {
     "title": "Murat Demirbas",
     "url": "https://muratbuffalo.blogspot.com/feeds/posts/default"
-  }
+  },
+  {
+    "title": "ParadeDB Blog",
+    "url": "https://paradedb.com/feed.xml"
+  },
 ]


### PR DESCRIPTION
Hi @samlambert. Thank you for running this feed.

- **Feed Title**: ParadeDB
- **Feed URL**: https://paradedb.com/feed.xml
- **Why is this feed valuable/authoritative?**: ParadeDB is a Postgres company building an Elasticsearch alternative for Postgres users.
