### PR TITLE
Filter transactional.blog to database posts

### DIFF
--- a/feeds.json
+++ b/feeds.json
@@ -71,7 +71,8 @@
   },
   {
     "title": "Alex Miller",
-    "url": "https://transactional.blog/feed.xml"
+    "url": "https://transactional.blog/feed.xml",
+    "filter_tags": ["databases"],
   },
   {
     "title": "Avinash Sajjanshetty",
@@ -88,10 +89,6 @@
   {
     "title": "Murat Demirbas",
     "url": "https://muratbuffalo.blogspot.com/feeds/posts/default"
-  },
-  {
-    "title": "transactional",
-    "url": "https://transactional.blog/feed.xml"
   },
   {
 


### PR DESCRIPTION
I have some non-database-y content coming up, so I finally added atom:category support to the RSS feed.  Most content is now tagged like

```
<category term="databases" scheme="https://transactional.blog/" label="databases"/>
```

which is what I'm hoping filter_tags is looking for, and I'll make sure some compiler/pl/tools/etc. stuff will get tagged otherwise