### PR TITLE
Fix feeds.json JSON format

### DIFF
--- a/feeds.json
+++ b/feeds.json
@@ -98,6 +98,7 @@
     "title": "ParadeDB Blog",
     "url": "https://paradedb.com/feed.xml"
   },
+  {
     "title": "Stack - Convex Blog",
     "url": "https://stack.convex.dev/rss/feed.xml",
     "filter_tags": [


### PR DESCRIPTION
Hello! 
New posts post July 29th are not showing up on the site.
This PR fixes the JSON format issue which appears to be introduced in commit [ad5a966](https://github.com/samlambert/database-news-feeds/commit/ad5a96618c1a6e9faf8e5bb20dde1c504b14227c) which may solve for it.
